### PR TITLE
Add a join function

### DIFF
--- a/sparse/base.py
+++ b/sparse/base.py
@@ -110,6 +110,22 @@ class BaseSparse:
             shape=self.shape,
         )
 
+    @classmethod
+    def join(cls, *tensors: Self) -> Self:
+        assert len(tensors) > 1
+        first_tensor, *_ = tensors
+        assert all(
+            map(
+                lambda tensor: id(tensor.indices) == id(first_tensor.indices),
+                tensors[1:],
+            )
+        )
+
+        values = torch.cat([tensor.values for tensor in tensors], dim=1)
+        return cls(
+            indices=first_tensor.indices, values=values, shape=first_tensor.shape
+        )
+
     def __repr__(self) -> str:
         return f"""{self.__class__.__name__}(shape={self.shape},
   indices={self._indices},

--- a/sparse/ops.py
+++ b/sparse/ops.py
@@ -52,6 +52,11 @@ class SparseOpsMixin(SparseScatterMixin):
             [self, other], _union_mask, lambda x: x[:, 0] - x[:, 1]
         )
 
+    def __neg__(self):
+        assert self.dtype != torch.bool
+
+        return self.__class__(self._indices, values=-self._values, shape=self.shape)
+
     @classmethod
     def _generic_ops(
         cls,
@@ -234,7 +239,11 @@ class SparseOpsMixin(SparseScatterMixin):
 
         brodcasted_tensors = []
         for tensor in tensors:
-            filtered_args = [(idx,dim,shape) for idx,dim,shape in broadcast if tensor.shape[dim] == 1]
+            filtered_args = [
+                (idx, dim, shape)
+                for idx, dim, shape in broadcast
+                if tensor.shape[dim] == 1
+            ]
 
             if len(filtered_args) == 0:
                 brodcasted_tensors.append(tensor)

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -111,6 +111,13 @@ def test_ops_sub():
 
 
 @assert_no_out_arr
+def test_ops_neg():
+    assert ((-a).to_dense() == -a.to_dense()).all()
+    assert ((-b).to_dense() == -b.to_dense()).all()
+    assert ((-c).to_dense() == -c.to_dense()).all()
+
+
+@assert_no_out_arr
 def test_ops_sparse_cart_prod():
     with pytest.raises(
         AssertionError, match="No input tensor, can't calculate the cartesian product"


### PR DESCRIPTION
Add a `SparseTensor.join` function to concatenate values of a sparse tensor.

## Demo

```python
import torch
from sparse import SparseTensor

indices = torch.tensor(
    [
        [0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1],
        [0, 0, 1, 1, 2, 2, 3, 3, 4, 5, 6],
        [0, 2, 1, 3, 2, 4, 3, 5, 4, 5, 6],
    ]
)
values1 = torch.randint(-32, 32, (indices.shape[1], 2))
values2 = torch.randint(-32, 32, (indices.shape[1], 3))
values3 = torch.randint(-32, 32, (indices.shape[1], 1))

tensor1 = SparseTensor(indices, values1, shape=(2, 8, 8))
tensor2 = tensor1.create_shared(values2)
tensor3 = tensor1.create_shared(values3)

join = SparseTensor.join(tensor1, tensor2, tensor3)

assert (join.values == torch.cat((values1, values2, values3), dim=1)).all()
```